### PR TITLE
Markdown format nr. 3

### DIFF
--- a/markdown-format.md
+++ b/markdown-format.md
@@ -11,18 +11,18 @@ format: scrollytelling
 - section steps are defined by h3 headings (`###`) in order to avoid underline
 - attributes are defined by HTML comments: `<!--{...}-->`
   - supports `#id`, `.class` and generic `attr="val"`
-  - if the attribute `as` is present, the entire element is replaced by that module, e.g. `# title <!--{as="eox-map"}-->` is entirely replaced by an `eox-map`
+  - if the attribute `as` is present, the entire element is replaced by that module, e.g. `# title <!--{as="eox-map"}-->` is entirely replaced by an `eox-map` with own rendering logic
 - the navigation is built automatically from all section headings, unless
   - it is disabled globally in the frontmatter (`nav: false`)
   - it is disabled for a specific section with the `<!--{no-nav}-->` attribute
 
 ---
-# Hero Title <!--{.hero .full style="background-image: url(https://placehold.co/1000x800)"}-->
+# Hero Title <!--{as="hero" .full style="background-image: url(https://placehold.co/1000x800)"}-->
 ## Hero subtitle
 Hero description
 
-# Container section <!--{.container}-->
-Description
+# Container section <!--{as="container"}-->
+Container section content
 
 # Sidecar section <!--{as="sidecar" .right}-->
 ### ![section-step 01](https://placehold.co/800x400)

--- a/markdown-format.md
+++ b/markdown-format.md
@@ -1,0 +1,37 @@
+---
+author: EOX
+tags:
+- earth
+- observation
+format: scrollytelling
+---
+
+# General concepts
+- sections are defined by h1 headings (`#`)
+- section steps are defined by h3 headings (`###`) in order to avoid underline
+- attributes are defined by HTML comments: `<!--{...}-->`
+  - supports `#id`, `.class` and generic `attr="val"`
+  - if the attribute `as` is present, the entire element is replaced by that module, e.g. `# title <!--{as="eox-map"}-->` is entirely replaced by an `eox-map`
+- the navigation is built automatically from all section headings, unless
+  - it is disabled globally in the frontmatter (`nav: false`)
+  - it is disabled for a specific section with the `<!--{no-nav}-->` attribute
+
+---
+# Hero Title <!--{.hero .full style="background-image: url(https://placehold.co/1000x800)"}-->
+## Hero subtitle
+Hero description
+
+# Container section <!--{.container}-->
+Description
+
+# Sidecar section <!--{as="sidecar" .right}-->
+### ![section-step 01](https://placehold.co/800x400)
+Sidecar step one
+### ![section-step 02](https://placehold.co/800x400)
+Sidecar step two
+
+# This is a map <!--{as="eox-map" .tour .left center=[0,0] zoom="7" stac="https://stac-catalog.org/01/item.json"}-->
+### ![section-step 01 placeholder](https://placehold.co/800x400) <!--{center=[48,15] zoom="10"}-->
+Description of step one
+### ![section-step 02 placeholder](https://placehold.co/800x400) <!--{stac="https://stac-catalog.org/01/item.json"}-->
+Description of step two


### PR DESCRIPTION
Using the package from quarto did not work out in the end, so we can come up with our entirely custom syntax.

This third approach is a kind of "Mix" between the two older approaches. It relies on a markdown-it plugin (old, but still working) https://github.com/rstacruz/markdown-it-decorate.

By passing attributes inside HTML comments and some additional rules, it allows creating a completely "clean looking" md file when rendered by GitHub (check the rich diff of the added file), but at the same time allowing to create all needed configs for our storytelling needs (I hope).

If this is agreed upon, the proposed roadmap for upcoming implementation would be:

- [ ] implement `markdown-it-decorate` (or any more up-to-date replacement, or own fork)
- [ ] implement section rendering + nav rendering for external md files
- [ ] implement eox-map section (tour mode) for external md files

This should give us some basic experience with which we can decide on how to continue (updating the editor, editor snippets, more sections etc.)